### PR TITLE
Remove curl, replace with fetch

### DIFF
--- a/post_install.sh
+++ b/post_install.sh
@@ -11,7 +11,7 @@ sysrc "duplicati_enable=YES"
 mkdir -p $duplicati_conf_dir
 mkdir -p $duplicati_dir
 cd $duplicati_dir
-curl -o duplicati.zip $dlurl
+fetch $dlurl -o duplicati.zip
 unzip duplicati.zip
 rm duplicati.zip
 pw user add duplicati -c duplicati -d /nonexistent -s /usr/bin/nologin


### PR DESCRIPTION
This uses [fetch(1)](https://www.freebsd.org/cgi/man.cgi?fetch(1)) instead of curl. fetch(1) exists in the base system so this eliminates the need for curl. 